### PR TITLE
[Homepage]: Get Mentorship from Alumni - Fix

### DIFF
--- a/client/src/components/Carousel/Carousel.styles.ts
+++ b/client/src/components/Carousel/Carousel.styles.ts
@@ -93,3 +93,10 @@ export const CarouselDiv = styled('div')`
     display: none;
   }
 `;
+
+export const CarouselToolbarContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+`;

--- a/client/src/components/Carousel/Carousel.styles.ts
+++ b/client/src/components/Carousel/Carousel.styles.ts
@@ -100,3 +100,14 @@ export const CarouselToolbarContainer = styled('div')`
   align-items: center;
   padding: 20px;
 `;
+
+export const CarouselNavContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+export const TopExploreBtnContainer = styled('div')`
+  @media screen and (max-width: 500px) {
+    display: none;
+  }
+`;

--- a/client/src/components/Carousel/Carousel.styles.ts
+++ b/client/src/components/Carousel/Carousel.styles.ts
@@ -86,11 +86,19 @@ export const StyledIconButton = styled(IconButton)(
 export const CarouselDiv = styled('div')`
   margin: 2rem;
   background: inherit;
+
   .swiper-button-prev {
     display: none;
   }
+
   .swiper-button-next {
     display: none;
+  }
+
+  .swiper-slide {
+    display: flex;
+    justify-content: center;
+    transition: all 0.4s ease;
   }
 `;
 

--- a/client/src/components/Carousel/Carousel.styles.ts
+++ b/client/src/components/Carousel/Carousel.styles.ts
@@ -119,3 +119,12 @@ export const TopExploreBtnContainer = styled('div')`
     display: none;
   }
 `;
+
+export const BottomExploreBtnContainer = styled('div')`
+  display: none;
+  @media screen and (max-width: 500px) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;

--- a/client/src/components/Carousel/CarouselToolbar.tsx
+++ b/client/src/components/Carousel/CarouselToolbar.tsx
@@ -35,19 +35,21 @@ const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
           </StyledButton>
         </Link>
       </TopExploreBtnContainer>
-      <div>
-        <StyledIconButton
-          aria-label="previous-page"
-          size="medium"
-          ref={prevRef}>
-          <ChevronLeftOutlined fontSize="inherit" />
-        </StyledIconButton>
-      </div>
-      <div>
-        <StyledIconButton aria-label="next page" size="medium" ref={nextRef}>
-          <ChevronRightOutlined fontSize="inherit" />
-        </StyledIconButton>
-      </div>
+      <Stack direction="row" spacing={2}>
+        <div>
+          <StyledIconButton
+            aria-label="previous-page"
+            size="medium"
+            ref={prevRef}>
+            <ChevronLeftOutlined fontSize="inherit" />
+          </StyledIconButton>
+        </div>
+        <div>
+          <StyledIconButton aria-label="next page" size="medium" ref={nextRef}>
+            <ChevronRightOutlined fontSize="inherit" />
+          </StyledIconButton>
+        </div>
+      </Stack>
     </CarouselNavContainer>
   </CarouselToolbarContainer>
 );

--- a/client/src/components/Carousel/CarouselToolbar.tsx
+++ b/client/src/components/Carousel/CarouselToolbar.tsx
@@ -39,13 +39,13 @@ const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
         <div>
           <StyledIconButton
             aria-label="previous-page"
-            size="medium"
+            size="large"
             ref={prevRef}>
             <ChevronLeftOutlined fontSize="inherit" />
           </StyledIconButton>
         </div>
         <div>
-          <StyledIconButton aria-label="next-page" size="medium" ref={nextRef}>
+          <StyledIconButton aria-label="next-page" size="large" ref={nextRef}>
             <ChevronRightOutlined fontSize="inherit" />
           </StyledIconButton>
         </div>

--- a/client/src/components/Carousel/CarouselToolbar.tsx
+++ b/client/src/components/Carousel/CarouselToolbar.tsx
@@ -4,7 +4,12 @@ import { Typography } from '@mui/material';
 import ChevronLeftOutlined from '@mui/icons-material/ChevronLeftOutlined';
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import { Link, StyledButton } from 'components/common';
-import { CarouselToolbarContainer, StyledIconButton } from './Carousel.styles';
+import {
+  CarouselNavContainer,
+  CarouselToolbarContainer,
+  StyledIconButton,
+  TopExploreBtnContainer,
+} from './Carousel.styles';
 interface AppProps {
   prevRef: React.RefObject<HTMLButtonElement>;
   nextRef: React.RefObject<HTMLButtonElement>;
@@ -22,10 +27,14 @@ const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
       }}>
       Get mentorship from Alumni
     </Typography>
-    <Stack direction="row" spacing={2}>
-      <Link to="/search">
-        <StyledButton sx={{ p: 2 }}>Explore all</StyledButton>
-      </Link>
+    <CarouselNavContainer>
+      <TopExploreBtnContainer>
+        <Link to="/search">
+          <StyledButton sx={{ p: 2, marginRight: '30px' }}>
+            Explore all
+          </StyledButton>
+        </Link>
+      </TopExploreBtnContainer>
       <div>
         <StyledIconButton
           aria-label="previous-page"
@@ -39,7 +48,7 @@ const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
           <ChevronRightOutlined fontSize="inherit" />
         </StyledIconButton>
       </div>
-    </Stack>
+    </CarouselNavContainer>
   </CarouselToolbarContainer>
 );
 

--- a/client/src/components/Carousel/CarouselToolbar.tsx
+++ b/client/src/components/Carousel/CarouselToolbar.tsx
@@ -4,44 +4,43 @@ import { Typography } from '@mui/material';
 import ChevronLeftOutlined from '@mui/icons-material/ChevronLeftOutlined';
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import { Link, StyledButton } from 'components/common';
-import { StyledIconButton } from './Carousel.styles';
+import { CarouselToolbarContainer, StyledIconButton } from './Carousel.styles';
 interface AppProps {
   prevRef: React.RefObject<HTMLButtonElement>;
   nextRef: React.RefObject<HTMLButtonElement>;
 }
 
 const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
-  <div
-    style={{
-      backgroundColor: '#242424',
-      margin: '0 2rem 1.5rem 1rem',
-    }}>
-    <Stack direction="row" alignItems="center">
-      <Typography
-        variant="h5"
-        sx={{ fontWeight: 700, flexGrow: 1, color: '#f5f5f5' }}>
-        Get mentorship from Alumni
-      </Typography>
-      <Stack direction="row" spacing={2}>
-        <Link to="/search">
-          <StyledButton sx={{ p: 2 }}>Explore all</StyledButton>
-        </Link>
-        <div>
-          <StyledIconButton
-            aria-label="previous-page"
-            size="medium"
-            ref={prevRef}>
-            <ChevronLeftOutlined fontSize="inherit" />
-          </StyledIconButton>
-        </div>
-        <div>
-          <StyledIconButton aria-label="next page" size="medium" ref={nextRef}>
-            <ChevronRightOutlined fontSize="inherit" />
-          </StyledIconButton>
-        </div>
-      </Stack>
+  <CarouselToolbarContainer>
+    <Typography
+      variant="h5"
+      sx={{
+        fontWeight: 700,
+        color: '#f5f5f5',
+        fontSize: '1.8rem',
+        paddingRight: '25px',
+      }}>
+      Get mentorship from Alumni
+    </Typography>
+    <Stack direction="row" spacing={2}>
+      <Link to="/search">
+        <StyledButton sx={{ p: 2 }}>Explore all</StyledButton>
+      </Link>
+      <div>
+        <StyledIconButton
+          aria-label="previous-page"
+          size="medium"
+          ref={prevRef}>
+          <ChevronLeftOutlined fontSize="inherit" />
+        </StyledIconButton>
+      </div>
+      <div>
+        <StyledIconButton aria-label="next page" size="medium" ref={nextRef}>
+          <ChevronRightOutlined fontSize="inherit" />
+        </StyledIconButton>
+      </div>
     </Stack>
-  </div>
+  </CarouselToolbarContainer>
 );
 
 export default CarouselToolbar;

--- a/client/src/components/Carousel/CarouselToolbar.tsx
+++ b/client/src/components/Carousel/CarouselToolbar.tsx
@@ -45,7 +45,7 @@ const CarouselToolbar: React.FC<AppProps> = ({ prevRef, nextRef }) => (
           </StyledIconButton>
         </div>
         <div>
-          <StyledIconButton aria-label="next page" size="medium" ref={nextRef}>
+          <StyledIconButton aria-label="next-page" size="medium" ref={nextRef}>
             <ChevronRightOutlined fontSize="inherit" />
           </StyledIconButton>
         </div>

--- a/client/src/components/Carousel/index.tsx
+++ b/client/src/components/Carousel/index.tsx
@@ -5,7 +5,8 @@ import { MentorSchemaType } from 'types';
 import 'swiper/swiper-bundle.min.css';
 import UserCard from 'components/UserCard';
 import Toolbar from './CarouselToolbar';
-import { CarouselDiv } from './Carousel.styles';
+import { Link, StyledButton } from 'components/common';
+import { BottomExploreBtnContainer, CarouselDiv } from './Carousel.styles';
 
 SwiperCore.use([Navigation, Mousewheel, Pagination]);
 
@@ -67,6 +68,15 @@ const Carousel = ({ userList }: { userList: Partial<MentorSchemaType>[] }) => {
           </SwiperSlide>
         ))}
       </Swiper>
+      <BottomExploreBtnContainer>
+        <Link to="/search">
+          <StyledButton
+            sx={{ p: 5 }}
+            style={{ padding: '20px', width: '300px' }}>
+            Explore all
+          </StyledButton>
+        </Link>
+      </BottomExploreBtnContainer>
     </CarouselDiv>
   );
 };

--- a/client/src/components/Carousel/index.tsx
+++ b/client/src/components/Carousel/index.tsx
@@ -56,7 +56,7 @@ const Carousel = ({ userList }: { userList: Partial<MentorSchemaType>[] }) => {
         // pagination={{ dynamicBullets: true, clickable: true }}
         freeMode
         grabCursor
-        // centeredSlides
+        centeredSlides
         mousewheel={{ forceToAxis: true }}
         // onSwiper={(swiper) => console.log(swiper)}
         // onSlideChange={() => console.log('slide change')}


### PR DESCRIPTION
This PR fixes #79 

I have made the carousel navigation buttons larger and also made the heading larger. Previously, the heading and the carousel navigation buttons were colliding and now they don't collide anymore. 

The carousel elements have been centered now by default so in smaller screen sizes, it would still be center aligned.

I have also added an additional "_Explore All_" button which is located below the carousel element. It is wider and bigger in size and is only visible for smaller screen sizes.
 
![carousel mobile preview](https://user-images.githubusercontent.com/64259328/163453744-8d7c0422-25c4-439c-9048-0e4a51ae7915.png)
